### PR TITLE
build: add build.rs to set rpath on macOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,@loader_path");
+
+    #[cfg(target_os = "linux")]
+    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+}


### PR DESCRIPTION
macOS only searches system library paths (i.e. /usr/lib) by default. In
order to use the bundled libSDL, it is necessary to set the rpath on the
executable.

See https://crates.io/crates/sdl2#bundled-feature.
